### PR TITLE
requestAnimationFrame will only trigger if the browser window is visi…

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -64,6 +64,7 @@ const factory = (Tab, TabContent, FontIcon) => {
     componentWillUnmount() {
       window.removeEventListener('resize', this.handleResize);
       clearTimeout(this.resizeTimeout);
+      if (this.updatePointerAnimationFrame) cancelAnimationFrame(this.updatePointerAnimationFrame);
     }
 
     getNewIndex(headers, delta) {
@@ -94,7 +95,7 @@ const factory = (Tab, TabContent, FontIcon) => {
 
     updatePointer = (idx) => {
       if (this.navigationNode && this.navigationNode.children[idx]) {
-        requestAnimationFrame(() => {
+        this.updatePointerAnimationFrame = requestAnimationFrame(() => {
           const nav = this.navigationNode.getBoundingClientRect();
           const label = this.navigationNode.children[idx].getBoundingClientRect();
           const scrollLeft = this.navigationNode.scrollLeft;


### PR DESCRIPTION
…ble. If the browser tab is put to the background, requestAnimationFrame will trigger when the tab returned to the foreground. When the Tabs Component is removed from the DOM when in the background, the requestAnimationFrame must be canceled to prevent attempting to use a unmounted Component. (#1604)