### PR TITLE
Improve tab accessibility

### DIFF
--- a/components/tabs/Tab.js
+++ b/components/tabs/Tab.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
@@ -39,21 +38,9 @@ const factory = (ripple, FontIcon) => {
       hidden: false,
     };
 
-    componentDidMount() {
-      this.handleFocus();
-    }
-
     componentDidUpdate(prevProps) {
       if (!prevProps.active && this.props.active && this.props.onActive) {
         this.props.onActive();
-      }
-      this.handleFocus();
-    }
-
-
-    handleFocus() {
-      if (this.props.active) {
-        ReactDOM.findDOMNode(this).focus();
       }
     }
 

--- a/components/tabs/TabContent.js
+++ b/components/tabs/TabContent.js
@@ -11,7 +11,7 @@ class TabContent extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     click: PropTypes.bool,
-    tabIndex: PropTypes.number,
+    hidden: PropTypes.bool,
     theme: PropTypes.shape({
       active: PropTypes.string,
       tab: PropTypes.string,
@@ -21,6 +21,7 @@ class TabContent extends Component {
   static defaultProps = {
     active: false,
     className: '',
+    hidden: true,
   };
 
   componentDidMount() {
@@ -35,10 +36,7 @@ class TabContent extends Component {
     }, this.props.className);
 
     return (
-      <section
-        className={className}
-        tabIndex={this.props.tabIndex}
-      >
+      <section className={className} role="tabpanel" aria-expanded={this.props.hidden}>
         {this.props.children}
       </section>
     );

--- a/components/tabs/TabContent.js
+++ b/components/tabs/TabContent.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
@@ -10,7 +9,6 @@ class TabContent extends Component {
     active: PropTypes.bool,
     children: PropTypes.node,
     className: PropTypes.string,
-    click: PropTypes.bool,
     hidden: PropTypes.bool,
     theme: PropTypes.shape({
       active: PropTypes.string,
@@ -23,12 +21,6 @@ class TabContent extends Component {
     className: '',
     hidden: true,
   };
-
-  componentDidMount() {
-    if (!this.props.click) {
-      ReactDOM.findDOMNode(this).focus();
-    }
-  }
 
   render() {
     const className = classnames(this.props.theme.tab, {

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
@@ -79,9 +80,15 @@ const factory = (Tab, TabContent, FontIcon) => {
       return newIndex;
     }
 
+    focusTab = (index) => {
+      const tabs = [...ReactDOM.findDOMNode(this).firstChild.querySelectorAll('[role=tab]')];
+      tabs[index].focus();
+    }
+
     handleHeaderClick = (idx) => {
       if (this.props.onChange) {
         this.props.onChange(idx);
+        this.focusTab(idx);
       }
     };
 

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -220,10 +220,10 @@ const factory = (Tab, TabContent, FontIcon) => {
             {hasLeftArrow && <div className={theme.arrowContainer} onClick={this.scrollRight}>
               <FontIcon className={theme.arrow} value="keyboard_arrow_left" />
             </div>}
-            <nav className={theme.navigation} ref={(node) => { this.navigationNode = node; }}>
+            <div className={theme.navigation} role="tablist" ref={(node) => { this.navigationNode = node; }}>
               {this.renderHeaders(headers)}
               <span className={classNamePointer} style={this.state.pointer} />
-            </nav>
+            </div>
             {hasRightArrow && <div className={theme.arrowContainer} onClick={this.scrollLeft}>
               <FontIcon className={theme.arrow} value="keyboard_arrow_right" />
             </div>}

--- a/components/tabs/config.css
+++ b/components/tabs/config.css
@@ -9,6 +9,7 @@
   --tab-navigation-border-color: var(--color-divider);
   --tab-pointer-color: var(--color-primary);
   --tab-pointer-height: calc(0.2 * var(--unit));
+  --tab-focus-color: color(var(--color-primary-contrast) a(10%));
   --tab-text: var(--color-black);
   --tab-text-color: var(--tab-text);
   --tab-text-inactive-color: color(var(--tab-text) a(70%));

--- a/components/tabs/theme.css
+++ b/components/tabs/theme.css
@@ -46,8 +46,13 @@
   position: relative;
   text-transform: uppercase;
   transition-duration: var(--animation-duration);
-  transition-property: box-shadow, color;
+  transition-property: background-color, box-shadow, color;
   transition-timing-function: var(--animation-curve-default);
+
+  &:focus {
+    background-color: var(--tab-focus-color);
+    outline: none;
+  }
 
   & > .rippleWrapper {
     overflow: hidden;


### PR DESCRIPTION
Bring in changes from react-toolbox for tab accessibility. Also, remove all focus setting on componentDidMount or componentDidUpdate for `TabContent.js` and `Tab.js`, which was automatically setting focus on the tab on page load. 
Now only set focus on click and/or left/right arrow event.