### PR TITLE
Adding aria-valuetext attribute to progress bar

### DIFF
--- a/components/progress_bar/ProgressBar.js
+++ b/components/progress_bar/ProgressBar.js
@@ -85,12 +85,13 @@ class ProgressBar extends Component {
       [theme.indeterminate]: mode === 'indeterminate',
       [theme.multicolor]: multicolor,
     }, className);
-
+    const roundedPercentage = Math.round(value * 100);
     return (
       <div
         disabled={disabled}
         role="progressbar"
         data-react-toolbox="progress-bar"
+        aria-valuetext={`${roundedPercentage}%`}
         aria-valuenow={value}
         aria-valuemin={min}
         aria-valuemax={max}


### PR DESCRIPTION
The aria-valuenow attribute represents the value rounded to the first digit
as a percentage