### PR TITLE
Allow tabs to be navigated with up and down keys

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -178,9 +178,9 @@ const factory = (Tab, TabContent, FontIcon) => {
 
     handleArrowPress(headers) {
       return (event) => {
-        if (event.key === 'ArrowRight') {
+        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
           this.handleHeaderClick(this.getNewIndex(headers, 1));
-        } else if (event.key === 'ArrowLeft') {
+        } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
           this.handleHeaderClick(this.getNewIndex(headers, -1));
         }
       };


### PR DESCRIPTION
A guideline is to code the page such that the up and left
arrows move left in the tablist and the right and down arrows
move right to allow for user error. Screen reader users will
encounter the page linearly and will not know if the page tabs
are horizontal or vertical, only that appear one after the other.