### PR TITLE
Switch Component Fix

### DIFF
--- a/components/switch/Switch.js
+++ b/components/switch/Switch.js
@@ -68,7 +68,6 @@ const factory = (Thumb) => {
             {...others}
             checked={this.props.checked}
             className={theme.input}
-            onClick={this.handleToggle}
             readOnly
             ref={(node) => { this.inputNode = node; }}
             type="checkbox"


### PR DESCRIPTION
handleToggle is being triggered twice with clicks of the switch.
Removing handleToggle from the input’s onClick, because it’s
sufficient to use the onClick of the span.