### PR TITLE
Removes randomness from RadioButton and Checkbox render

### DIFF
--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -10,6 +10,7 @@ import checkFactory from './Check';
 
 const factory = (Check) => {
   class Checkbox extends Component {
+
     static propTypes = {
       checked: PropTypes.bool,
       children: PropTypes.node,
@@ -38,6 +39,11 @@ const factory = (Check) => {
       disabled: false,
     };
 
+    constructor(props) {
+      super(props);
+      this._id = uuidv4();
+    }
+
     handleToggle = (event) => {
       if (event.pageX !== 0 && event.pageY !== 0) this.blur();
       if (!this.props.disabled && this.props.onChange) {
@@ -63,8 +69,8 @@ const factory = (Check) => {
       const className = classnames(theme.field, {
         [theme.disabled]: this.props.disabled,
       }, this.props.className);
-      const inputId = `input_${uuidv4()}`;
-      const labelId = `label_${uuidv4()}`;
+      const inputId = `input_${this._id}`;
+      const labelId = `label_${this._id}`;
 
       return (
         <label

--- a/components/radio/RadioButton.js
+++ b/components/radio/RadioButton.js
@@ -9,6 +9,7 @@ import radioFactory from './Radio';
 
 const factory = (Radio) => {
   class RadioButton extends Component {
+
     static propTypes = {
       checked: PropTypes.bool,
       children: PropTypes.node,
@@ -38,6 +39,11 @@ const factory = (Radio) => {
       className: '',
       disabled: false,
     };
+
+    constructor(props) {
+      super(props);
+      this._id = uuidv4();
+    }
 
     handleClick = (event) => {
       const { checked, disabled, onChange } = this.props;
@@ -72,8 +78,8 @@ const factory = (Radio) => {
         ...others
       } = this.props;
       const _className = classnames(theme[this.props.disabled ? 'disabled' : 'field'], className);
-      const inputId = `input_${uuidv4()}`;
-      const labelId = `label_${uuidv4()}`;
+      const inputId = `input_${this._id}`;
+      const labelId = `label_${this._id}`;
 
       return (
         <label


### PR DESCRIPTION
Removes calls to uuid.v4() from the render methods of the
above components. This avoids unnecessarily flushing to the DOM
when the component hasn't changed.